### PR TITLE
Add support for ManyToMany fields in page content models with the ability to apply filter_horizontal to them.

### DIFF
--- a/src/cms/apps/pages/admin.py
+++ b/src/cms/apps/pages/admin.py
@@ -143,7 +143,7 @@ class PageAdmin(PageBaseAdmin):
     def formfield_for_manytomany(self, db_field, request=None, **kwargs):
         content_cls = self.get_page_content_cls(request)
         formfield = super(PageAdmin, self).formfield_for_manytomany(db_field, request=None, **kwargs)
-        if getattr(content_cls, "filter_horizontal", "") and db_field.name in content_cls.filter_horizontal:
+        if db_field.name in getattr(content_cls, "filter_horizontal", ()):
             formfield.widget = FilteredSelectMultiple(
                 verbose_name = db_field.verbose_name,
                 is_stacked = False,


### PR DESCRIPTION
This pull requests adds functionality to the page content models by allowing ManyToMany fields to be used in addition to standard CharFields etc.

In addition, filter_horizontal can be applied to the ManyToMany fields by setting it as an attribute in your model:

``` python
class Content(ContentBase):

    example = models.ManyToManyField(
        ExampleModel,
    )

    filter_horizontal = ("example", )
```
