### PR TITLE
Update the media app to use the new Truncator class

### DIFF
--- a/src/cms/apps/media/admin.py
+++ b/src/cms/apps/media/admin.py
@@ -7,7 +7,7 @@ from django.contrib import admin
 from django.contrib.admin.views.main import IS_POPUP_VAR
 from django.shortcuts import render
 from django.template.defaultfilters import filesizeformat
-from django.utils.text import truncate_words
+from django.utils.text import Truncator
 
 import optimizations
 
@@ -166,7 +166,7 @@ class FileAdminBase(admin.ModelAdmin):
     
     def get_title(self, obj):
         """Returns a truncated title of the object."""
-        return truncate_words(obj.title, 8)
+        return Truncator(obj.title).words(8)
     get_title.short_description = "title"
     
     # Custom view logic.


### PR DESCRIPTION
The `django.utils.text.truncate_words()` function is removed in Django 1.5 and deprecated in the current stable release. This pull request updates the media app to use the replacement Truncator class.

Works with apps running on the current stable release (1.4.3) as well as the current 1.5 RC.
