### PR TITLE
Use a relative path for the project template

### DIFF
--- a/src/cms/bin/start_cms_project.py
+++ b/src/cms/bin/start_cms_project.py
@@ -4,6 +4,7 @@
 Starts a new CMS project with the given name.
 """
 
+import os
 import sys
 
 from django.core import management
@@ -15,8 +16,8 @@ def start_cms_project():
         raise management.CommandError("start_cms_project accepts one argument - the name of the project to create.")
     management.call_command("startproject",
         argv[1],
-        template = "~/Workspace/cms/src/cms/project_template/",
-        n = "py,css,html",
+        template = "{}/../project_template/".format(os.path.dirname( __file__ )),
+        n = "py,css,html,gitignore",
     )
 
 


### PR DESCRIPTION
This commit changes the template path from a absolute path to a relative one, based on the location of the start_cms_project.py script.

Fixes #19 
